### PR TITLE
Task-4 Brackets validator for Movie title

### DIFF
--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -13,5 +13,6 @@
 #
 
 class Movie < ApplicationRecord
+  validates_with TitleBracketsValidator
   belongs_to :genre
 end

--- a/app/validators/title_brackets_validator.rb
+++ b/app/validators/title_brackets_validator.rb
@@ -1,0 +1,33 @@
+class TitleBracketsValidator < ActiveModel::Validator
+  def validate(record)
+    @title = record.title
+    @matching_brackets = { "{" => "}", "(" => ")", "[" => "]" }
+    @allow_empty = options[:allow_empty] || false
+    record.errors.add(:title, "Invalid title") if !valid?
+  end
+
+  private
+
+  def valid?
+    opening_brackets_occurences = []
+    closing_brackets = @matching_brackets.values
+    return false if !@allow_empty && have_empty_brackets?
+
+    @title.split("").each do |c|
+      opening_brackets_occurences.push(c) if @matching_brackets.key?(c)
+      next unless closing_brackets.include?(c)
+      last_opening_bracket = opening_brackets_occurences.pop
+      return false unless brackets_match?(last_opening_bracket, c)
+    end
+
+    opening_brackets_occurences.empty?
+  end
+
+  def have_empty_brackets?
+    /\(\)|\[\]|\{\}/.match? @title
+  end
+
+  def brackets_match?(opening, closing)
+    opening && @matching_brackets[opening] == closing
+  end
+end

--- a/spec/validators/title_brackets_validator_spec.rb
+++ b/spec/validators/title_brackets_validator_spec.rb
@@ -1,87 +1,87 @@
-# require "rails_helper"
+require "rails_helper"
 
-# describe TitleBracketsValidator do
-#   subject { Validatable.new(title: title) }
+describe TitleBracketsValidator do
+  subject { Validatable.new(title: title) }
 
-#   shared_examples "has valid title" do
-#     it "should be valid" do
-#       expect(subject).to be_valid
-#     end
-#   end
+  shared_examples "has valid title" do
+    it "should be valid" do
+      expect(subject).to be_valid
+    end
+  end
 
-#   shared_examples "has invalid title" do
-#     it "should not be valid" do
-#       expect(subject).not_to be_valid
-#     end
-#   end
+  shared_examples "has invalid title" do
+    it "should not be valid" do
+      expect(subject).not_to be_valid
+    end
+  end
 
-#   context "with curly brackets" do
-#     let(:title) { "The Fellowship of the Ring {Peter Jackson}" }
-#     it_behaves_like "has valid title"
-#   end
+  context "with curly brackets" do
+    let(:title) { "The Fellowship of the Ring {Peter Jackson}" }
+    it_behaves_like "has valid title"
+  end
 
-#   context "with square brackets" do
-#     let(:title) { "The Fellowship of the Ring [Lord of The Rings]" }
-#     it_behaves_like "has valid title"
-#   end
+  context "with square brackets" do
+    let(:title) { "The Fellowship of the Ring [Lord of The Rings]" }
+    it_behaves_like "has valid title"
+  end
 
-#   context "with not closed brackets" do
-#     let(:title) { "The Fellowship of the Ring (2001" }
-#     it_behaves_like "has invalid title"
-#   end
+  context "with not closed brackets" do
+    let(:title) { "The Fellowship of the Ring (2001" }
+    it_behaves_like "has invalid title"
+  end
 
-#   context "with not opened brackets" do
-#     let(:title) { "The Fellowship of the Ring 2001)" }
-#     it_behaves_like "has invalid title"
-#   end
+  context "with not opened brackets" do
+    let(:title) { "The Fellowship of the Ring 2001)" }
+    it_behaves_like "has invalid title"
+  end
 
-#   context "with not too much closing brackets" do
-#     let(:title) { "The Fellowship of the Ring (2001) - 2003)" }
-#     it_behaves_like "has invalid title"
-#   end
+  context "with not too much closing brackets" do
+    let(:title) { "The Fellowship of the Ring (2001) - 2003)" }
+    it_behaves_like "has invalid title"
+  end
 
-#   context "with not too much opening brackets" do
-#     let(:title) { "The Fellowship of the Ring (2001 - (2003)" }
-#     it_behaves_like "has invalid title"
-#   end
+  context "with not too much opening brackets" do
+    let(:title) { "The Fellowship of the Ring (2001 - (2003)" }
+    it_behaves_like "has invalid title"
+  end
 
-#   context "with empty brackets" do
-#     let(:title) { "The Fellowship of the Ring ()" }
-#     it_behaves_like "has invalid title"
-#   end
+  context "with empty brackets" do
+    let(:title) { "The Fellowship of the Ring ()" }
+    it_behaves_like "has invalid title"
+  end
 
-#   context "with brackets in wrong order" do
-#     let(:title) { "The Fellowship of the )Ring(" }
-#     it_behaves_like "has invalid title"
-#   end
+  context "with brackets in wrong order" do
+    let(:title) { "The Fellowship of the )Ring(" }
+    it_behaves_like "has invalid title"
+  end
 
-#   context "with matching brackets" do
-#     let(:title) { "The Fellowship of the Ring (2001)" }
-#     it_behaves_like "has valid title"
-#   end
+  context "with matching brackets" do
+    let(:title) { "The Fellowship of the Ring (2001)" }
+    it_behaves_like "has valid title"
+  end
 
-#   context "with multiple matching brackets" do
-#     let(:title) { "The Fellowship of the Ring [Lord of The Rings] (2001) {Peter Jackson}" }
-#     it_behaves_like "has valid title"
-#   end
+  context "with multiple matching brackets" do
+    let(:title) { "The Fellowship of the Ring [Lord of The Rings] (2001) {Peter Jackson}" }
+    it_behaves_like "has valid title"
+  end
 
-#   context "with nested matching brackets" do
-#     let(:title) { "The Fellowship of the Ring [Lord of The Rings {Peter Jackson}] (2012)" }
-#     it_behaves_like "has valid title"
-#   end
+  context "with nested matching brackets" do
+    let(:title) { "The Fellowship of the Ring [Lord of The Rings {Peter Jackson}] (2012)" }
+    it_behaves_like "has valid title"
+  end
 
-#   context "with no brackets" do
-#     let(:title) { "Lord of The Rings" }
-#     it_behaves_like "has valid title"
-#   end
-# end
+  context "with no brackets" do
+    let(:title) { "Lord of The Rings" }
+    it_behaves_like "has valid title"
+  end
+end
 
-# class Validatable
-#   include ActiveModel::Validations
-#   validates_with TitleBracketsValidator
-#   attr_accessor :title
+class Validatable
+  include ActiveModel::Validations
+  validates_with TitleBracketsValidator
+  attr_accessor :title
 
-#   def initialize(title:)
-#     @title = title
-#   end
-# end
+  def initialize(title:)
+    @title = title
+  end
+end


### PR DESCRIPTION
Task 4 - brackets validation
Added bracket validator, with optional parameter :allow_empty, by default brackets can't ne empty.